### PR TITLE
Updating packages

### DIFF
--- a/ProjectCoimbra.UWP/Project.Coimbra.Midi/DryWetMidiIntegration/MarkablePlayback.cs
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Midi/DryWetMidiIntegration/MarkablePlayback.cs
@@ -70,8 +70,8 @@ namespace Coimbra.DryWetMidiIntegration
 
             this.TempoMap = tempoMap;
 
-            this.regularPrecisionTickGenerator = new RegularPrecisionTickGenerator(ClockInterval);
-            this.clock = new MidiClock(true, this.regularPrecisionTickGenerator);
+            this.regularPrecisionTickGenerator = new RegularPrecisionTickGenerator();
+            this.clock = new MidiClock(true, this.regularPrecisionTickGenerator, ClockInterval);
             this.clock.Ticked += this.OnClockTick;
 
             this.ProcessInstrumentNotes();

--- a/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
@@ -134,7 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Melanchall.DryWetMidi">
-      <Version>5.1.0</Version>
+      <Version>5.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>

--- a/ProjectCoimbra.UWP/Project.Coimbra/Extensions/ObservableCollectionExtensions.cs
+++ b/ProjectCoimbra.UWP/Project.Coimbra/Extensions/ObservableCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Coimbra.Extensions
         /// <param name="position">Func determining position of value.</param>
         public static void SortIn<T>(this ObservableCollection<T> collection, T value, Func<T, int> position)
         {
-            if (collection == null)
+            if (collection == null || position == null)
             {
                 return;
             }

--- a/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
@@ -160,7 +160,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">
-      <Version>3.0.0</Version>
+      <Version>3.3.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -168,18 +168,13 @@
       <Version>1.6.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.6.0</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <Version>3.6.0</Version>
+      <Version>3.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.0.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
-      <Version>3.0.0</Version>
+      <Version>3.3.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -187,13 +182,13 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Input.GazeInteraction">
-      <Version>6.1.0</Version>
+      <Version>6.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.2</Version>
+      <Version>2.4.3</Version>
     </PackageReference>
     <PackageReference Include="Roslynator.Analyzers">
-      <Version>2.3.0</Version>
+      <Version>3.0.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ProjectCoimbra.UWP/Project.Coimbra/ProjectCoimbra.ruleset
+++ b/ProjectCoimbra.UWP/Project.Coimbra/ProjectCoimbra.ruleset
@@ -43,15 +43,6 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0060" Action="Info" />
   </Rules>
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.PublicApiAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.PublicApiAnalyzers">
-    <Rule Id="RS0016" Action="Error" />
-    <Rule Id="RS0017" Action="Error" />
-    <Rule Id="RS0022" Action="Error" />
-    <Rule Id="RS0024" Action="Error" />
-    <Rule Id="RS0025" Action="Error" />
-    <Rule Id="RS0026" Action="Error" />
-    <Rule Id="RS0027" Action="Error" />
-  </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.VersionCheckAnalyzer" RuleNamespace="Microsoft.CodeAnalysis.VersionCheckAnalyzer">
     <Rule Id="CA9999" Action="Error" />
   </Rules>


### PR DESCRIPTION
Fixes #2 and potentially #3, as the issues related to #3 are not reproing for me following this change.

Updating NuGet packages to the most recent versions available. The PR also includes the code updates necessitated by the upgrade to the code analysis packages.

The update removes the dependency on the `Microsoft.CodeAnalysis.PublicApiAnalyzers` package. This package is for facilitating consumption of our libraries by external callers, which is not the intended use. Therefore, it was decided that this change does not add value here and the dependency was removed. If we were to retain it at it's latest version, we would have to create a set of text files documenting the API surface, again adding little value in this context.