### PR TITLE
Adding CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @EnableIrelandAT @andreasbalzer @ceakarsu @muiriswoulfe


### PR DESCRIPTION
Adding a `CODEOWNERS` file to the repo, to facilitate PR reviewing.

See the [GitHub docs](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) for more information about this file.