### PR TITLE
Preventing generation of intermediate .editorconfig output files

### DIFF
--- a/ProjectCoimbra.UWP/Project.Coimbra.Communication/Project.Coimbra.Communication.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Communication/Project.Coimbra.Communication.csproj
@@ -16,6 +16,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
@@ -16,6 +16,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Model/Project.Coimbra.Model.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Model/Project.Coimbra.Model.csproj
@@ -16,6 +16,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
@@ -32,6 +32,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
+    <GenerateMSBuildEditorConfigFile>false</GenerateMSBuildEditorConfigFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Adding `<GenerateMSBuildEditorConfigFile>` attribute to all of the .csproj files in the project, to avoid the generation of intermediate outputs that should not be committed to the repo.