### PR TITLE
Making SDK versions consistent

### DIFF
--- a/ProjectCoimbra.UWP/Project.Coimbra.Communication/Project.Coimbra.Communication.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Communication/Project.Coimbra.Communication.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Project.Coimbra.Communication</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Communication/Project.Coimbra.Communication.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Communication/Project.Coimbra.Communication.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/ProjectCoimbra.UWP/Project.Coimbra.DataAccess/Project.Coimbra.DataAccess.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.DataAccess/Project.Coimbra.DataAccess.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/ProjectCoimbra.UWP/Project.Coimbra.DataAccess/Project.Coimbra.DataAccess.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.DataAccess/Project.Coimbra.DataAccess.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Project.Coimbra.DataAccess</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Midi/Project.Coimbra.Midi.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Project.Coimbra.Midi</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Model/Project.Coimbra.Model.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Model/Project.Coimbra.Model.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/ProjectCoimbra.UWP/Project.Coimbra.Model/Project.Coimbra.Model.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra.Model/Project.Coimbra.Model.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Project.Coimbra.Model</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
@@ -26,7 +26,7 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
@@ -35,10 +35,11 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
-    <PackageCertificateThumbprint>14E0AB75F568C80F57B2493A3A94CBE5E6328092</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>3E658D9A386AC7DD0693B315D4E25EAA5325FED3</PackageCertificateThumbprint>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <PackageCertificateKeyFile>Project.Coimbra_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -163,6 +164,7 @@
     <Content Include="Strings\en-US\Terms.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Project.Coimbra_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -262,8 +264,8 @@
       <Name>Microsoft General MIDI DLS for Universal Windows Apps</Name>
     </SDKReference>
   </ItemGroup>
-  <ItemGroup> 
-    <ProjectReference Include="..\DataAccessLibrary\Project.Coimbra.DataAccess.csproj">
+  <ItemGroup>
+    <ProjectReference Include="..\Project.Coimbra.DataAccess\Project.Coimbra.DataAccess.csproj">
       <Project>{060b8571-854f-4c66-b802-fc93211fe12b}</Project>
       <Name>Project.Coimbra.DataAccess</Name>
     </ProjectReference>
@@ -285,7 +287,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="Microsoft.Midi.GmDls, Version=10.0.18362.0">
+    <SDKReference Include="Microsoft.Midi.GmDls, Version=10.0.19041.0">
       <Name>Microsoft General MIDI DLS for Universal Windows Apps</Name>
     </SDKReference>
   </ItemGroup>

--- a/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
@@ -35,11 +35,10 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
-    <PackageCertificateThumbprint>3E658D9A386AC7DD0693B315D4E25EAA5325FED3</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>14E0AB75F568C80F57B2493A3A94CBE5E6328092</PackageCertificateThumbprint>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
-    <PackageCertificateKeyFile>Project.Coimbra_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -164,7 +163,6 @@
     <Content Include="Strings\en-US\Terms.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="Project.Coimbra_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
+++ b/ProjectCoimbra.UWP/Project.Coimbra/Project.Coimbra.csproj
@@ -25,7 +25,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseVSHostingProcess>false</UseVSHostingProcess>


### PR DESCRIPTION
Making the Windows SDK versions within the project consistent, to avoid errors about version mismatches.

This also includes a small project file update.